### PR TITLE
Empty postgres_users variable and add role_attr_flags attribute in 'E…

### DIFF
--- a/role_postgres/defaults/main.yml
+++ b/role_postgres/defaults/main.yml
@@ -38,9 +38,7 @@ postgresql_hba_entries:
 
 
 # Databases to ensure exist.
-postgresql_databases: 
-  - name: test_db
-    owner: almabud
+postgresql_databases: []
 # - name: exampledb # required; the rest are optional
 #   lc_collate: # defaults to 'en_US.UTF-8'
 #   lc_ctype: # defaults to 'en_US.UTF-8'
@@ -55,9 +53,7 @@ postgresql_databases:
 #   state: # defaults to 'present'
 
 # Users to ensure exist.
-postgresql_users:
-  - name: almabud
-    password: 1234
+postgresql_users: []
 # - name: jdoe #required; the rest are optional
 #   password: # defaults to not set
 #   encrypted: # defaults to not set

--- a/role_postgres/tasks/users.yml
+++ b/role_postgres/tasks/users.yml
@@ -3,13 +3,14 @@
   postgresql_user:
     name: "{{ item.name }}"
     password: "{{ item.password | default(omit) }}"
+    role_attr_flags: "{{ item.role_attr_flags | default(omit) }}"
     login_host: "{{ item.login_host | default('localhost') }}"
     login_password: "{{ item.login_password | default(postgresql_user) }}"
     login_user: "{{ item.login_user | default(postgresql_user) }}"
     login_unix_socket: "{{ item.login_unix_socket | default(postgresql_unix_socket_directories[0]) }}"
     port: "{{ item.port | default(omit) }}"
   with_items: "{{ postgresql_users }}"
-  # no_log: "{{ postgres_users_no_log }}"
+  no_log: "{{ postgres_users_no_log }}"
   become: true
   become_user: "{{ postgresql_user }}"
   # See: https://github.com/ansible/ansible/issues/16048#issuecomment-229012509


### PR DESCRIPTION
- Change the postgres_users in the default variable
-  Add no_log in the 'Ensure PostgreSQL users are present.' task
-  Add role_attr_flags for the  Postgres create user